### PR TITLE
Fix "Mythical Man-Month" entry

### DIFF
--- a/TheTechTree.md
+++ b/TheTechTree.md
@@ -178,7 +178,7 @@ _Computer Networking: A Top-down Approach_ by Jim Kurose (Pearson)
 
 The line-by-line act of writing software is quite different from the team-by-team process of developing, testing, integrating, and deploying it. A few key approaches, tools, and roles are described here, including, for obvious reasons, unpacking Git itself.
 
-_Mythical Man-Month, The: Essays on Software Engineering, Anniversary Edition Anniversary Edition by Frederick Brooks Jr.
+_Mythical Man-Month, The: Essays on Software Engineering, Anniversary Edition_ by Frederick Brooks Jr.
 
 _Working in Public: The Making and Maintenance of Open Source Software_ by Nadia Eghbal (Stripe Press)
 


### PR DESCRIPTION
"Mythical Man-Month" misses the end of the emphasis, and "Anniversary Edition" is duplicated.