### PR TITLE
Add Structure and Interpretation of Computer Programs

### DIFF
--- a/TheTechTree.md
+++ b/TheTechTree.md
@@ -112,6 +112,8 @@ _Introducing Python_ by Bill Lubanovic (O&#39;Reilly)
 
 _Comprehensive Ruby Programming_ by Jordan Hudgens (Packt)
 
+_Structure and Interpretation of Computer Programs_ by Harold Abelson, Gerald Jay Sussman, Julie Sussman (MIT Press)
+
 _LISP, Lore, and Logic_ by W. Richard Stark (Springer)
 
 _The C Programming Language_ by Kernighan and Ritchie (Pearson)


### PR DESCRIPTION
"Structure and Interpretation of Computer Programs" by Harold Abelson, Gerald
Jay Sussman and Julie Sussman from MIT Press is one of the canonical computer
science books teaching programming in LISP.

https://en.wikipedia.org/wiki/Structure_and_Interpretation_of_Computer_Programs

It is licensed under CC BY-SA 4.0.