### PR TITLE
add some books about Windows

### DIFF
--- a/TheTechTree.md
+++ b/TheTechTree.md
@@ -87,6 +87,10 @@ _Mastering Linux Kernel Development_ by Raghu Bharadwaj (Packt)
 
 _The Linux Programming Interface_ by Michael Kerrick (No Starch)
 
+_Windows Internals, Seventh Edition_, Parts 1 and 2, by Pavel Yosifovich, Alex Ionescu, Mark E. Russinovich, and David A. Solomon (Microsoft)
+
+_The Old New Thing: Practical Development Throughout the Evolution of Windows_ by Raymond Chen (Addison-Wesley)
+
 ## Programming languages
 
 There are hundreds of programming languages; the enormous chart visualizing their evolution at the Computer History Museum is worth visiting if you&#39;re a developer, and we don&#39;t intend to document them all. Still, accessible book-length descriptions of a selection of the world&#39;s major languages seems desirable.


### PR DESCRIPTION
The amount of software written for Microsoft Windows makes information about it extremely valuable.

Additionally, I assume https://github.com/MicrosoftDocs/sdk-api, https://github.com/MicrosoftDocs/windows-driver-docs, https://github.com/MicrosoftDocs/windows-driver-docs-ddi, etc. are already included in the set of repositories, but http://undocumented.ntinternals.net/ and https://www.geoffchappell.com/ (note https://www.geoffchappell.com/about/terms.htm!) might also be useful to include somehow, to provide additional perspectives and information.