### PR TITLE
add x86 manual

### DIFF
--- a/TheTechTree.md
+++ b/TheTechTree.md
@@ -279,6 +279,8 @@ _RISC-V Specifications_ by the RISC-V International Technical Committee
 
 _Learning FPGAs_ by Justin Rajewski (O&#39;Reilly)
 
+_Intel® 64 and IA-32 Architectures Software Developer’s Manual Combined Volumes: 1, 2A, 2B, 2C, 2D, 3A, 3B, 3C, 3D, and 4_ (Intel)
+
 ## Hardware development
 
 _Digital Computer Electronics_ by Albert P. Malvino and Jerald A Brown (Career Education)

--- a/TheTechTree.md
+++ b/TheTechTree.md
@@ -279,7 +279,7 @@ _RISC-V Specifications_ by the RISC-V International Technical Committee
 
 _Learning FPGAs_ by Justin Rajewski (O&#39;Reilly)
 
-_Intel® 64 and IA-32 Architectures Software Developer’s Manual Combined Volumes: 1, 2A, 2B, 2C, 2D, 3A, 3B, 3C, 3D, and 4_ (Intel)
+_Intel® 64 and IA-32 Architectures Software Developer’s Manual Combined Volumes: 1, 2A, 2B, 2C, 2D, 3A, 3B, 3C, 3D, and 4_ (Lulu)
 
 ## Hardware development
 


### PR DESCRIPTION
x86 is the most commonly-used architecture for most software currently, so therefore a specification of it would be quite valuable to include. Here are some useful links to find the document:

- https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html
- https://cdrdv2.intel.com/v1/dl/getContent/671200
- https://www.lulu.com/spotlight/intelsdm